### PR TITLE
update plistlib load

### DIFF
--- a/src/alfred.py
+++ b/src/alfred.py
@@ -19,7 +19,8 @@ UNESCAPE_CHARACTERS = u""" ;()"""
 
 _MAX_RESULTS_DEFAULT = 9
 
-preferences = plistlib.readPlist('info.plist')
+with open('info.plist', 'rb') as f:
+    preferences = plistlib.load(f)
 bundleid = preferences['bundleid']
 
 


### PR DESCRIPTION
Fixed plistlib error:
```
Traceback (most recent call last):
...
    import alfred
...
    preferences = plistlib.readPlist('info.plist')
AttributeError: module 'plistlib' has no attribute 'readPlist'
```