### PR TITLE
Fix key string type error 💻 python:3.9 macos:15.1

### DIFF
--- a/src/otp.py
+++ b/src/otp.py
@@ -8,6 +8,8 @@ import time
 
 
 def get_hotp_token(key, intervals_no):
+    if isinstance(key, str):
+    key = key.encode()
     msg = struct.pack(">Q", intervals_no)
     h = hmac.new(key, msg, hashlib.sha1).digest()
     o = h[19] & 15


### PR DESCRIPTION
Error Info:
TypeError: key: expected bytes or bytearray, but got 'str'