### PR TITLE
Explicitly mark non-actionable items as such

### DIFF
--- a/src/alfred.py
+++ b/src/alfred.py
@@ -146,7 +146,7 @@ class AlfredWorkflow(object):
         return Item({
             u'uid': get_uid(uid),
             u'arg': '',
-            u'ignore': 'yes'
+            u'valid': 'no'
         }, title, message, icon)
 
     def warning_item(self, title, message, uid=0):

--- a/src/workflow.py
+++ b/src/workflow.py
@@ -87,7 +87,7 @@ class AlfredGAuth(alfred.AlfredWorkflow):
         # The uid for the remaining time will be the current time,
         # so it will appears always at the last position in the list
         time_remaining = otp.get_totp_time_remaining()
-        return alfred.Item({u'uid': time.time(), u'arg': '', u'ignore': 'yes'},
+        return alfred.Item({u'uid': time.time(), u'arg': '', u'valid': 'no'},
                            'Time Remaining: {}s'.format(time_remaining),
                            None, 'time.png')
 


### PR DESCRIPTION
Previously all non-actionable items (e.g. `Time Remaining...`, `GAuth is not yet configured`, etc.) were using `ignore="yes"` XML attribute, which Alfred didn't recognize. Because of this, the user was able to hit ENTER (or click) on that item, which resulted in:
* an empty input was sent to the clipboard paste and show notification actions;
* Alfred's search bar was closed.

This change explicitly marks these items as non-actionable so that user can't use them.