### PR TITLE
Replace Travis CI integration with GitHub Actions

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-            pip install pep8
+            install pycodestyle
 
       - name: Run tests
         run: |
-          pep8 src/*.py
+          pycodestyle src/*.py

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,0 +1,34 @@
+name: Docs
+
+on:
+  push:
+    paths: ['src/**', '.github/workflows/code_style.yml.yml']
+  pull_request:
+    paths: ['src/**', '.github/workflows/code_style.yml.yml']
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  tests:
+    name: Code Style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+
+      - name: Install dependencies
+        run: |
+            pip install pep8
+
+      - name: Run tests
+        run: |
+          pep8 src/*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: python
-sudo: false
-install: pip install pep8
-script: pep8 src/*.py

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Alfred Workflow: Google Authenticator
 =====================================
 
-[![Build Status](https://travis-ci.org/moul/alfred-workflow-gauth.svg?branch=master)](https://travis-ci.org/moul/alfred-workflow-gauth)
+[![Build Status](https://github.com/moul/alfred-workflow-gauth/actions/workflows/code_style.yml/badge.svg)](https://github.com/moul/alfred-workflow-gauth/actions/workflows/code_style.yml)
 
 An Alfred 2 workflow for Google Authenticator / a.k.a. Two-Factors Authentication / a.k.a. Time-Based Authentication Token / a.k.a. TOTP
 


### PR DESCRIPTION
Travis CI doesn't support open source projects for a long time now. This PR uses GitHub Actions for the same checks.

P.S.
I can't really tell if this workflow works before it's merged into the `master` branch.